### PR TITLE
Add colors for splitters and underground belts

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,7 +1,15 @@
 -- changes color of base belts
 data.raw["transport-belt"]["transport-belt"].friendly_map_color = {r = .98, g = .73, b = 0.0} -- 250, 186, 0
+data.raw["underground-belt"]["underground-belt"].ifriendly_map_color = {r = .98, g = .73, b = 0.0} -- 250, 186, 0
+data.raw["splitter"]["splitter"].friendly_map_color = {r = .98, g = .73, b = 0.0} -- 250, 186, 0
+
 data.raw["transport-belt"]["fast-transport-belt"].friendly_map_color = {r = .98, g = .27, b = .06} -- 250, 69, 15 
+data.raw["underground-belt"]["fast-underground-belt"].friendly_map_color = {r = .98, g = .27, b = .06} -- 250, 69, 15 
+data.raw["splitter"]["fast-splitter"].friendly_map_color = {r = .98, g = .27, b = .06} -- 250, 69, 15 
+
 data.raw["transport-belt"]["express-transport-belt"].friendly_map_color = {r = .15, g = .67, b = .71}  -- 38, 171, 181
+data.raw["underground-belt"]["express-underground-belt"].friendly_map_color = {r = .15, g = .67, b = .71}  -- 38, 171, 181
+data.raw["splitter"]["express-splitter"].friendly_map_color = {r = .15, g = .67, b = .71}  -- 38, 171, 181
 
 --changes color of pipes/storage tank
 data.raw["pipe"]["pipe"].friendly_map_color = {r = .29, g = .09, b = .56} -- 74, 23, 143


### PR DESCRIPTION
It works for me for version 0.14.21.

It looks like it does not when loading game, because Factorio does not redraw existing items, only new ones.